### PR TITLE
Harden Renovate config and fix Dockerfile casing

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -71,6 +71,12 @@
       "groupName": "devDependencies",
       "matchDepTypes": [
         "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
       ]
     },
     {

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-bookworm as builder
+FROM golang:1.26.3-bookworm AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26.1.0 as builder
+FROM node:26.1.0 AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm install


### PR DESCRIPTION
## What

- `.github/renovate.json`: restrict the `devDependencies` group to `minor`/`patch`/`pin`/`digest` so major updates land in dedicated PRs.
- `frontend/Dockerfile`, `backend/Dockerfile`: change `FROM <image> as builder` → `AS builder`.

## Why

Prevent recurrence of the outage that #129 fixed: PR #15 (`update devDependencies`) bundled Biome 1→2 and Tailwind 3→4 together, which made the breaking-change review invisible. The Dockerfile change is a trivial fix for BuildKit's `FromAsCasing` warning.

The workflow `concurrency` change originally part of this PR (#135) is being moved to a separate follow-up because PR modifications to workflow files appear to suppress same-PR workflow runs in this repo; will revisit under #133.

Closes #130, #132.

## Test plan

- [ ] CI green