### PR TITLE
Add backend logout endpoint

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"61707d02-085c-4bbb-96bc-f011424314e4","pid":69338,"procStart":"Sun May 17 16:33:17 2026","acquiredAt":1779037446211}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"61707d02-085c-4bbb-96bc-f011424314e4","pid":69338,"procStart":"Sun May 17 16:33:17 2026","acquiredAt":1779037446211}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .clinerules
+.claude/
 .env

--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -155,6 +155,28 @@ func HandleLogin(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 }
 
+// HandleLogout clears the session_token cookie so the client is no longer authenticated.
+// The session token is stateless (HMAC-signed claims), so no server-side revocation is needed —
+// instructing the browser to drop the cookie is sufficient.
+func HandleLogout(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session_token",
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   r.TLS != nil,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // HandleCallback processes the OAuth callback from Google
 func HandleCallback(w http.ResponseWriter, r *http.Request) {
 	if !authEnabled {

--- a/backend/auth/auth_test.go
+++ b/backend/auth/auth_test.go
@@ -217,3 +217,53 @@ func TestGetCurrentUser(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleLogout(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		expectedStatus int
+		expectsClear   bool
+	}{
+		{
+			name:           "POST clears cookie",
+			method:         http.MethodPost,
+			expectedStatus: http.StatusNoContent,
+			expectsClear:   true,
+		},
+		{
+			name:           "GET is rejected",
+			method:         http.MethodGet,
+			expectedStatus: http.StatusMethodNotAllowed,
+			expectsClear:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/api/auth/logout", nil)
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: "some-token"})
+			rr := httptest.NewRecorder()
+
+			auth.HandleLogout(rr, req)
+
+			assert.Equal(t, tc.expectedStatus, rr.Code)
+
+			if !tc.expectsClear {
+				return
+			}
+
+			cookies := rr.Result().Cookies()
+			var sessionCookie *http.Cookie
+			for _, c := range cookies {
+				if c.Name == "session_token" {
+					sessionCookie = c
+					break
+				}
+			}
+			assert.NotNil(t, sessionCookie, "session_token cookie should be set in response")
+			assert.Empty(t, sessionCookie.Value)
+			assert.Less(t, sessionCookie.MaxAge, 0, "MaxAge should be negative to delete cookie")
+		})
+	}
+}

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -64,6 +64,7 @@ func (r *Router) SetupRoutes() http.Handler {
 	// Auth routes
 	mux.HandleFunc("/api/auth/login", auth.HandleLogin)
 	mux.HandleFunc("/api/auth/callback", auth.HandleCallback)
+	mux.HandleFunc("/api/auth/logout", auth.HandleLogout)
 	mux.HandleFunc("/api/auth/user", r.handleCurrentUser)
 
 	// Health check endpoints
@@ -84,6 +85,7 @@ func (r *Router) SetupRoutes() http.Handler {
 			"/api/analytics/top",
 			"/api/auth/login",
 			"/api/auth/callback",
+			"/api/auth/logout",
 			"/api/auth/user",
 			"/health",
 			"/health/detailed",

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -84,9 +84,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // Logout handling
   const logout = async () => {
-    // Just remove session on client side for now (should have backend logout API in production)
-    document.cookie =
-      "session_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;"
+    try {
+      await axios.post(
+        `${API_BASE_URL}/auth/logout`,
+        null,
+        { withCredentials: true },
+      )
+    } catch (err) {
+      console.error("Logout request failed:", err)
+    }
     setUser(null)
   }
 


### PR DESCRIPTION
## What

- Add `POST /api/auth/logout` (`auth.HandleLogout`) that clears the `session_token` cookie via `MaxAge: -1`. `GET` is rejected with 405.
- Wire the route in `backend/routes/routes.go`.
- Update `frontend/src/contexts/AuthContext.tsx` `logout()` to `POST` the endpoint with `withCredentials: true` instead of writing an expired cookie from JS.
- Add unit tests for `HandleLogout` covering the success path and method-not-allowed.
- Ignore `.claude/` locally-managed agent state in `.gitignore`.

## Why

The previous client-side logout (`document.cookie = "session_token=; expires=..."`) only works for cookies readable from JS. The login flow already issues the cookie as `HttpOnly`, so JS could not actually delete it — the session remained valid until natural expiry. A server-side endpoint is also the only correct logout flow if the cookie is — or is later strengthened to — `HttpOnly`, and it gives the backend a hook for future revocation lists. Biome v2 flagged the JS write as `lint/suspicious/noDocumentCookie`.

Closes #131.

## Test plan

- [x] `go test ./auth/...` passes (new TestHandleLogout cases)
- [x] `npm run lint` clean (noDocumentCookie warning removed)
- [x] `npm run test` — all 22 tests pass
- [ ] CI green