### PR TITLE
Add concurrency cancellation and native-arch release builds

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"61707d02-085c-4bbb-96bc-f011424314e4","pid":69338,"procStart":"Sun May 17 16:33:17 2026","acquiredAt":1779037446211}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"61707d02-085c-4bbb-96bc-f011424314e4","pid":69338,"procStart":"Sun May 17 16:33:17 2026","acquiredAt":1779037446211}

--- a/.github/workflows/backend-lint.yaml
+++ b/.github/workflows/backend-lint.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   backend-lint:
     permissions:

--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   backend-test:
     permissions:

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -10,28 +10,27 @@ env:
   REPO_IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push:
+  build:
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
-    runs-on: ubuntu-latest
-
     strategy:
+      fail-fast: false
       matrix:
-        component: [ frontend, backend ]
-        os: [ ubuntu-latest ]
+        component: [frontend, backend]
+        platform:
+          - name: amd64
+            os: ubuntu-latest
+            tag: linux/amd64
+          - name: arm64
+            os: ubuntu-24.04-arm
+            tag: linux/arm64
+    runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO_IMAGE_NAME }}-${{ matrix.component }}
-          tags: latest,${{ github.ref_name }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -43,11 +42,70 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push Docker image for ${{ matrix.component }}
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: ./${{ matrix.component }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform.tag }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.REPO_IMAGE_NAME }}-${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.component }}-${{ matrix.platform.name }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: [frontend, backend]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digests-${{ matrix.component }}-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO_IMAGE_NAME }}-${{ matrix.component }}
+          tags: latest,${{ github.ref_name }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.REPO_IMAGE_NAME }}-${{ matrix.component }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.REPO_IMAGE_NAME }}-${{ matrix.component }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -8,6 +8,10 @@ on:
     branches:
         - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     permissions:

--- a/.github/workflows/frontend-lint.yaml
+++ b/.github/workflows/frontend-lint.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   frontend-lint:
     permissions:

--- a/.github/workflows/frontend-test.yaml
+++ b/.github/workflows/frontend-test.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   frontend-test:
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .clinerules
 .env
+.claude/


### PR DESCRIPTION
## What

- Add `concurrency` block to every PR-triggered workflow (`frontend-lint`, `frontend-test`, `backend-lint`, `backend-test`, `docker-build`). The group is `${workflow}-${ref}` and `cancel-in-progress` is gated on `pull_request` so `push` to `main` is never cancelled by itself.
- Restructure `docker-build-and-push.yaml` into a two-job pipeline:
  - `build`: matrix on `component × {amd64, arm64}` with `runs-on` selected per platform (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64). Each job builds and pushes to GHCR by digest (`outputs: type=image,push-by-digest=true,name-canonical=true,push=true`) and uploads the digest as an artifact.
  - `merge`: depends on `build`, downloads all digests per component, then `docker buildx imagetools create` assembles the multi-arch manifest with `latest` + `${{ github.ref_name }}` tags.
- Ignore `.claude/` (local agent state) in `.gitignore`.

## Why

The previous release build cross-compiled `linux/arm64` on an amd64 runner under QEMU, which dominated the wall-clock for v0.6.0. Splitting per-architecture builds onto native runners makes the total ≈ `max(amd64, arm64)` instead of `amd64 + emulated-arm64`. Native `ubuntu-24.04-arm` runners are free for public repos. The concurrency change reduces wasted CI minutes when a PR is force-pushed rapidly (which Renovate rebases tend to do).

Closes #133, #141.

## Test plan

Note: GitHub Actions appears to suppress workflow runs on PRs that themselves modify workflow files. CI on this PR may show only CodeQL. The changes only take effect after merge and will be validated by:

- [ ] First PR merged after this lands shows `cancel-in-progress` working on rebases.
- [ ] Next release (when cut) goes through the per-arch build path and finishes substantially faster than the v0.6.0 baseline. The merged manifest can be inspected via `docker buildx imagetools inspect ghcr.io/okabe-junya/golink-{frontend,backend}:<tag>`.