### PR TITLE
Fix release build: lowercase image name for GHCR

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -32,6 +32,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Compute lowercase image name
+        id: image
+        run: echo "name=$(echo '${{ env.REGISTRY }}/${{ env.REPO_IMAGE_NAME }}-${{ matrix.component }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -50,7 +54,7 @@ jobs:
           platforms: ${{ matrix.platform.tag }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.REPO_IMAGE_NAME }}-${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -76,6 +80,10 @@ jobs:
       matrix:
         component: [frontend, backend]
     steps:
+      - name: Compute lowercase image name
+        id: image
+        run: echo "name=$(echo '${{ env.REGISTRY }}/${{ env.REPO_IMAGE_NAME }}-${{ matrix.component }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -97,15 +105,15 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO_IMAGE_NAME }}-${{ matrix.component }}
+          images: ${{ steps.image.outputs.name }}
           tags: latest,${{ github.ref_name }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.REPO_IMAGE_NAME }}-${{ matrix.component }}@sha256:%s ' *)
+            $(printf '${{ steps.image.outputs.name }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.REPO_IMAGE_NAME }}-${{ matrix.component }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ steps.image.outputs.name }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## What

Compute a lowercase image reference (`ghcr.io/okabe-junya/golink-${component}`) once per job via `tr '[:upper:]' '[:lower:]'`, and use it in `outputs:` of `build-push-action`, in `metadata-action`'s `images:`, in `imagetools create`'s digest references, and in `imagetools inspect`.

## Why

The v0.6.1 release build failed with:

```
ERROR: failed to build: failed to solve: failed to parse ref
"ghcr.io/Okabe-Junya/golink-frontend": invalid reference format:
repository name (Okabe-Junya/golink-frontend) must be lowercase
```

`github.repository` is the GitHub-stylized owner/repo (mixed case), and the previous workflow happened to work because `docker/metadata-action` lowercases its outputs internally. The new per-arch pipeline introduced in #143 passes the image name directly to `outputs=...,name=...` of `docker/build-push-action`, which doesn't normalize, so the build fails before pushing.

## Test plan

- [ ] CI green on this PR
- [ ] Cut a follow-up patch release after merge; release build should produce both arch images and a merged manifest at `ghcr.io/okabe-junya/golink-{frontend,backend}:vX.Y.Z` and `:latest`