### PR TITLE
Drop stale go: 1.23 pin from backend/.golangci.yaml (closes #155)

### DIFF
--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -1,6 +1,5 @@
 version: "2"
 run:
-  go: "1.23"
   allow-parallel-runners: true
 linters:
   default: none


### PR DESCRIPTION
## What

Remove the explicit `run.go: \"1.23\"` line from `backend/.golangci.yaml` so golangci-lint reads the Go version from `backend/go.mod` (currently `1.25.0`).

## Why

`run.go` controls which Go-version semantics linters like `staticcheck` and `govet` apply. Pinned to 1.23 while the module builds against 1.25, the linter quietly uses older rules. Reading from `go.mod` keeps lint config in sync with the module.

## Test plan

- [x] `golangci-lint run ./...` reports zero issues from `backend/`

Closes #155