### PR TITLE
Reject attacker-controlled X-User-ID header and validate link URLs

### DIFF
--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -325,14 +325,18 @@ func GetCurrentUser(r *http.Request) (*User, error) {
 		})
 	}
 
-	// Fall back to header for compatibility or testing
-	userID := r.Header.Get("X-User-ID")
-	if userID != "" {
-		return &User{
-			ID:    userID,
-			Email: r.Header.Get("X-User-Email"),
-			Name:  r.Header.Get("X-User-Name"),
-		}, nil
+	// Trust the X-User-ID header as identity ONLY in test mode. In production this
+	// header is attacker-controlled, so honoring it would let any unauthenticated
+	// client impersonate an arbitrary user (auth bypass).
+	if os.Getenv("TEST_MODE") == "true" {
+		userID := r.Header.Get("X-User-ID")
+		if userID != "" {
+			return &User{
+				ID:    userID,
+				Email: r.Header.Get("X-User-Email"),
+				Name:  r.Header.Get("X-User-Name"),
+			}, nil
+		}
 	}
 
 	return nil, errors.New("not authenticated")

--- a/backend/auth/auth_test.go
+++ b/backend/auth/auth_test.go
@@ -218,6 +218,40 @@ func TestGetCurrentUser(t *testing.T) {
 	}
 }
 
+// TestGetCurrentUser_HeaderNotTrustedInProduction pins the fix for the auth-bypass
+// where GetCurrentUser trusted an attacker-controlled X-User-ID header. With auth
+// enabled and no session cookie, the header must NOT authenticate a user unless
+// TEST_MODE is explicitly set.
+func TestGetCurrentUser_HeaderNotTrustedInProduction(t *testing.T) {
+	t.Setenv("AUTH_DISABLED", "false")
+	t.Setenv("GOOGLE_CLIENT_ID", "test-client-id")
+	t.Setenv("GOOGLE_CLIENT_SECRET", "test-client-secret")
+	if err := auth.InitAuth(); err != nil {
+		t.Fatalf("InitAuth failed: %v", err)
+	}
+
+	newReq := func() *http.Request {
+		req := httptest.NewRequest("GET", "/api/links", nil)
+		req.Header.Set("X-User-ID", "victim@example.com")
+		return req
+	}
+
+	t.Run("production rejects the header", func(t *testing.T) {
+		t.Setenv("TEST_MODE", "")
+		user, err := auth.GetCurrentUser(newReq())
+		assert.Error(t, err)
+		assert.Nil(t, user)
+	})
+
+	t.Run("test mode still honors the header", func(t *testing.T) {
+		t.Setenv("TEST_MODE", "true")
+		user, err := auth.GetCurrentUser(newReq())
+		assert.NoError(t, err)
+		assert.NotNil(t, user)
+		assert.Equal(t, "victim@example.com", user.ID)
+	})
+}
+
 func TestHandleLogout(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/backend/auth/session.go
+++ b/backend/auth/session.go
@@ -123,7 +123,8 @@ func ValidateSessionToken(token string) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	if signature != expectedSignature {
+	// Constant-time comparison to avoid leaking the expected signature via timing.
+	if !hmac.Equal([]byte(signature), []byte(expectedSignature)) {
 		return nil, errors.New("invalid token signature")
 	}
 

--- a/backend/handlers/link_handler.go
+++ b/backend/handlers/link_handler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -33,12 +35,29 @@ func getUserFromContext(r *http.Request) (string, string) {
 		return user.ID, user.Email
 	}
 
-	// Fall back to header for backward compatibility
-	userID := r.Header.Get("X-User-ID")
-	if userID == "" {
-		userID = "anonymous"
+	// In production the AuthMiddleware always sets the context user before a handler
+	// runs, so reaching here means auth is disabled or we are under test. Only trust
+	// the X-User-ID header in test mode; otherwise it is attacker-controlled.
+	if os.Getenv("TEST_MODE") == "true" {
+		if userID := r.Header.Get("X-User-ID"); userID != "" {
+			return userID, ""
+		}
 	}
-	return userID, ""
+	return "anonymous", ""
+}
+
+// validateTargetURL ensures a link target is an absolute http(s) URL, rejecting
+// schemes such as javascript:, data:, or file: that would enable stored XSS when
+// the target is later rendered as an anchor href or emitted in a redirect Location.
+func validateTargetURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	return u.Host != ""
 }
 
 // CreateLink handles POST /api/links requests
@@ -78,6 +97,10 @@ func (h *LinkHandler) CreateLink(w http.ResponseWriter, r *http.Request) {
 			"short":      requestBody.Short,
 			"defaultURL": targetURL,
 		})
+	} else if !validateTargetURL(targetURL) {
+		http.Error(w, "URL must be an absolute http or https URL", http.StatusBadRequest)
+		logger.Warn("Invalid target URL", logger.Fields{"short": requestBody.Short})
+		return
 	}
 
 	// Validate short code format (alphanumeric and hyphen only)
@@ -390,9 +413,10 @@ func (h *LinkHandler) UpdateLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Only the creator can update this link
-	// If userId is anonymous, this allows also update by anonymous users
-	if userID != "anonymous" && link.CreatedBy != userID && auth.IsAuthEnabled() {
+	// Only the creator can update this link. When auth is disabled the tool runs in
+	// anonymous mode and edits are open; when auth is enabled ownership is enforced
+	// (an "anonymous" userID must not be able to edit another user's link).
+	if auth.IsAuthEnabled() && link.CreatedBy != userID {
 		http.Error(w, "Only the creator can update this link", http.StatusForbidden)
 		logger.Warn("Unauthorized update attempt", logger.Fields{
 			"short":       short,
@@ -416,6 +440,11 @@ func (h *LinkHandler) UpdateLink(w http.ResponseWriter, r *http.Request) {
 
 	// Update the link fields
 	if requestBody.URL != "" {
+		if !validateTargetURL(requestBody.URL) {
+			http.Error(w, "URL must be an absolute http or https URL", http.StatusBadRequest)
+			logger.Warn("Invalid target URL on update", logger.Fields{"short": short})
+			return
+		}
 		link.URL = requestBody.URL
 	}
 
@@ -530,9 +559,10 @@ func (h *LinkHandler) DeleteLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Skip permission check if auth is disabled or anonymous user
-	// Otherwise only the creator can delete this link
-	if userID != "anonymous" && link.CreatedBy != userID && auth.IsAuthEnabled() {
+	// When auth is disabled the tool runs in anonymous mode and deletes are open;
+	// when auth is enabled only the creator can delete this link (an "anonymous"
+	// userID must not be able to delete another user's link).
+	if auth.IsAuthEnabled() && link.CreatedBy != userID {
 		http.Error(w, "Only the creator can delete this link", http.StatusForbidden)
 		logger.Warn("Unauthorized delete attempt", logger.Fields{
 			"short":       short,
@@ -710,8 +740,9 @@ func (h *LinkHandler) DeleteExpiredLinks(w http.ResponseWriter, r *http.Request)
 
 	var deletedCount int
 	for _, link := range links {
-		// Only delete links that the user has permission to delete
-		if link.CreatedBy != userID && userID != "anonymous" {
+		// Only delete links the user owns. When auth is disabled (anonymous mode)
+		// all expired links are eligible; when enabled, ownership is enforced.
+		if auth.IsAuthEnabled() && link.CreatedBy != userID {
 			continue
 		}
 

--- a/backend/repositories/link_repository.go
+++ b/backend/repositories/link_repository.go
@@ -78,11 +78,13 @@ func (r *LinkRepository) GetByShort(ctx context.Context, short string) (*models.
 	// Update expiry status if needed
 	if !link.ExpiresAt.IsZero() && time.Now().After(link.ExpiresAt) && !link.IsExpired {
 		link.IsExpired = true
-		// Update the link in the background, don't block the response
+		// Persist in the background on a *copy*: the background writer mutates
+		// UpdatedAt and marshals the struct while the caller concurrently reads the
+		// returned pointer, so they must not share the same *Link (data race).
+		linkCopy := link
 		go func() {
-			// Create a new context for the background operation
 			bgCtx := context.Background()
-			if err := r.Update(bgCtx, &link); err != nil {
+			if err := r.Update(bgCtx, &linkCopy); err != nil {
 				// We're in a goroutine, so we can't return the error
 				// Ideally, we would log this error
 			}
@@ -160,21 +162,21 @@ func (r *LinkRepository) Delete(ctx context.Context, short string) error {
 	return nil
 }
 
-// IncrementClickCount increments the click count for a link
+// IncrementClickCount increments the click count for a link.
+//
+// This fires from a background goroutine on every redirect, so a read-modify-write
+// of the whole document would lose increments under concurrency and, worse, clobber
+// a concurrent edit (URL/access-level change) with a stale snapshot. Update only the
+// counter field via an atomic server-side increment instead.
 func (r *LinkRepository) IncrementClickCount(ctx context.Context, short string) error {
-	// Get the link
-	link, err := r.GetByShort(ctx, short)
+	_, err := r.client.Collection(r.collection).Doc(short).Update(ctx, []firestore.Update{
+		{Path: "click_count", Value: firestore.Increment(1)},
+		{Path: "updated_at", Value: time.Now()},
+	})
 	if err != nil {
-		return err // Already wrapped by GetByShort
-	}
-
-	// Increment the click count
-	link.ClickCount++
-	link.UpdatedAt = time.Now()
-
-	// Update the link
-	_, err = r.client.Collection(r.collection).Doc(short).Set(ctx, link)
-	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return errors.NewNotFound(fmt.Sprintf("Link '%s' not found", short))
+		}
 		return errors.NewInternalError(fmt.Errorf("Error updating click count: %w", err))
 	}
 


### PR DESCRIPTION
## What

Close an authentication/authorization bypass and harden the link store.

- **Auth bypass (critical).** `auth.GetCurrentUser` and `handlers.getUserFromContext` trusted the `X-User-ID` (and `X-User-Email`/`X-User-Name`) request header as identity whenever the `session_token` cookie was absent or invalid. Because this ran on the production path, any unauthenticated client could send `X-User-ID: <victim>` and be treated as that user — reading Private/Restricted links and forging `created_by`. Header trust is now gated behind `TEST_MODE`; production returns "not authenticated".
- **Ownership guard escape.** The update/delete/expired-cleanup guards were keyed on `userID != "anonymous"`, so sending `X-User-ID: anonymous` short-circuited the `403` and let an unauthenticated caller modify or delete *any* link. Ownership is now enforced with `auth.IsAuthEnabled() && link.CreatedBy != userID`, which still allows open editing in anonymous mode (auth disabled) but denies cross-user writes when auth is on.
- **Stored XSS / open redirect.** Link targets were stored with no scheme validation, so `javascript:`/`data:` URLs were persisted and later rendered as an anchor `href` and emitted in the redirect `Location`. Targets must now parse as absolute `http(s)` URLs.
- **Constant-time signature check.** Session signature comparison used `!=` on strings; switched to `hmac.Equal`.
- **Data race + lost update.** `GetByShort` handed the same `*Link` to a background writer and the caller (a data race under `-race`); it now copies before the goroutine. `IncrementClickCount` did a whole-document read-modify-write from a per-redirect goroutine, losing increments and able to clobber concurrent edits; it now issues an atomic `firestore.Increment` on the counter field only.

Added a regression test (`TestGetCurrentUser_HeaderNotTrustedInProduction`) pinning that the header is rejected in production and honored only under `TEST_MODE`.

## Why

These are objective security/correctness defects on the production request path of a deployed, publicly-visible URL shortener. The header-trust bypass in particular defeats the entire Google OAuth flow and the domain allowlist, so it is fixed first and covered by a test.

## Note

Two pre-existing test failures in `routes` (`TestCORSMiddleware/Without_CORS_ORIGIN`, `TestRoutes/Options_Request`) reproduce on clean `origin/main` and are unrelated to this change — the CORS middleware returns empty `Access-Control-*` headers under those test conditions. Tracked separately so this PR stays scoped to the security fix. All other packages pass under `go test -race`.
