### PR TITLE
Fix handlers-package tests to authenticate under TEST_MODE

### DIFF
--- a/backend/handlers/link_handler_test.go
+++ b/backend/handlers/link_handler_test.go
@@ -13,8 +13,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// setupTestHandler creates a new LinkHandler with a mock repository for testing
-func setupTestHandler() (*LinkHandler, *mocks.MockLinkRepository) {
+// setupTestHandler creates a new LinkHandler with a mock repository for testing.
+// TEST_MODE is the same test-only authentication contract used elsewhere in this
+// codebase (see auth.GetCurrentUser / getUserFromContext): only under TEST_MODE
+// does the handler trust an X-User-ID header as identity, since these tests call
+// handler methods directly and never pass through AuthMiddleware.
+func setupTestHandler(t *testing.T) (*LinkHandler, *mocks.MockLinkRepository) {
+	t.Setenv("TEST_MODE", "true")
 	mockRepo := mocks.NewMockLinkRepository()
 	handler := NewLinkHandler(mockRepo)
 	return handler, mockRepo
@@ -29,7 +34,7 @@ func createTestLink(short, url, userID string) *models.Link {
 
 func TestCreateLink(t *testing.T) {
 	// Setup
-	handler, mockRepo := setupTestHandler()
+	handler, mockRepo := setupTestHandler(t)
 
 	// Create a test link
 	testLink := createTestLink("test", "https://example.com", "user1")
@@ -114,7 +119,7 @@ func TestCreateLink(t *testing.T) {
 
 func TestGetLinks(t *testing.T) {
 	// Setup
-	handler, mockRepo := setupTestHandler()
+	handler, mockRepo := setupTestHandler(t)
 
 	// Add some test links to the mock repository
 	ctx := context.Background()
@@ -205,7 +210,7 @@ func TestGetLinks(t *testing.T) {
 
 func TestGetLink(t *testing.T) {
 	// Setup
-	handler, mockRepo := setupTestHandler()
+	handler, mockRepo := setupTestHandler(t)
 
 	// Add a test link to the mock repository
 	ctx := context.Background()
@@ -281,7 +286,7 @@ func TestGetLink(t *testing.T) {
 
 func TestUpdateLink(t *testing.T) {
 	// Setup
-	handler, mockRepo := setupTestHandler()
+	handler, mockRepo := setupTestHandler(t)
 
 	// Add a test link to the mock repository
 	ctx := context.Background()
@@ -350,7 +355,7 @@ func TestUpdateLink(t *testing.T) {
 
 func TestDeleteLink(t *testing.T) {
 	// Setup
-	handler, mockRepo := setupTestHandler()
+	handler, mockRepo := setupTestHandler(t)
 
 	// Add a test link to the mock repository
 	ctx := context.Background()
@@ -401,7 +406,7 @@ func TestDeleteLink(t *testing.T) {
 
 func TestRedirectLink(t *testing.T) {
 	// Setup
-	handler, mockRepo := setupTestHandler()
+	handler, mockRepo := setupTestHandler(t)
 
 	// Add test links to the mock repository
 	ctx := context.Background()
@@ -479,7 +484,7 @@ func TestRedirectLink(t *testing.T) {
 
 func TestHealthCheck(t *testing.T) {
 	// Setup
-	handler, _ := setupTestHandler()
+	handler, _ := setupTestHandler(t)
 
 	// Create request
 	req, _ := http.NewRequest(http.MethodGet, "/health", nil)


### PR DESCRIPTION
## What

Fix `TestCreateLink`, `TestGetLinks`, `TestGetLink`, `TestUpdateLink`, `TestDeleteLink`, and `TestRedirectLink` (backend/handlers), which fail on a clean `main` after #186. `setupTestHandler` now sets `TEST_MODE=true` via `t.Setenv` before constructing the handler, so requests that send `X-User-ID` legitimately authenticate as that user through the same test-only trust path `auth.GetCurrentUser` / `getUserFromContext` already define.

## Why

These tests call handler methods directly (`handler.CreateLink(rr, req)`, etc.), bypassing `AuthMiddleware`, and relied on `X-User-ID` being trusted unconditionally as identity. #186 (ref. #186) closed that as a production auth bypass and gated header trust behind `TEST_MODE`, so the tests started resolving every request to `"anonymous"` regardless of the header — e.g. `TestCreateLink` asserted `CreatedBy == "user1"` but got `"anonymous"`, and ownership-guarded cases in `TestGetLink`/`TestUpdateLink`/`TestDeleteLink`/`TestRedirectLink` got `403` instead of the owner's `200`/`204`. This surfaced while fixing #187. #186's behavior is correct and unchanged by this PR; only the stale test setup is fixed, using the same `TEST_MODE` contract `routes_test.go` already relies on. Requests that send no `X-User-ID` continue to resolve to `"anonymous"` exactly as before.