### PR TITLE
Align handler test user-identity expectations with anonymous auth behavior

### DIFF
--- a/backend/handlers/link_handler_test.go
+++ b/backend/handlers/link_handler_test.go
@@ -28,6 +28,10 @@ func createTestLink(short, url, userID string) *models.Link {
 }
 
 func TestCreateLink(t *testing.T) {
+	// TEST_MODE lets getUserFromContext honor the X-User-ID header (see #186);
+	// without it every request resolves to "anonymous" regardless of the header.
+	t.Setenv("TEST_MODE", "true")
+
 	// Setup
 	handler, mockRepo := setupTestHandler()
 
@@ -113,6 +117,10 @@ func TestCreateLink(t *testing.T) {
 }
 
 func TestGetLinks(t *testing.T) {
+	// TEST_MODE lets getUserFromContext honor the X-User-ID header (see #186);
+	// without it every request resolves to "anonymous" regardless of the header.
+	t.Setenv("TEST_MODE", "true")
+
 	// Setup
 	handler, mockRepo := setupTestHandler()
 
@@ -204,6 +212,10 @@ func TestGetLinks(t *testing.T) {
 }
 
 func TestGetLink(t *testing.T) {
+	// TEST_MODE lets getUserFromContext honor the X-User-ID header (see #186);
+	// without it every request resolves to "anonymous" regardless of the header.
+	t.Setenv("TEST_MODE", "true")
+
 	// Setup
 	handler, mockRepo := setupTestHandler()
 
@@ -280,6 +292,10 @@ func TestGetLink(t *testing.T) {
 }
 
 func TestUpdateLink(t *testing.T) {
+	// TEST_MODE lets getUserFromContext honor the X-User-ID header (see #186);
+	// without it every request resolves to "anonymous" regardless of the header.
+	t.Setenv("TEST_MODE", "true")
+
 	// Setup
 	handler, mockRepo := setupTestHandler()
 
@@ -349,6 +365,10 @@ func TestUpdateLink(t *testing.T) {
 }
 
 func TestDeleteLink(t *testing.T) {
+	// TEST_MODE lets getUserFromContext honor the X-User-ID header (see #186);
+	// without it every request resolves to "anonymous" regardless of the header.
+	t.Setenv("TEST_MODE", "true")
+
 	// Setup
 	handler, mockRepo := setupTestHandler()
 
@@ -400,6 +420,10 @@ func TestDeleteLink(t *testing.T) {
 }
 
 func TestRedirectLink(t *testing.T) {
+	// TEST_MODE lets getUserFromContext honor the X-User-ID header (see #186);
+	// without it every request resolves to "anonymous" regardless of the header.
+	t.Setenv("TEST_MODE", "true")
+
 	// Setup
 	handler, mockRepo := setupTestHandler()
 


### PR DESCRIPTION
## What

`TestCreateLink`, `TestGetLinks`, `TestGetLink`, `TestUpdateLink`, `TestDeleteLink`, and `TestRedirectLink` in `backend/handlers/link_handler_test.go` set an `X-User-ID` request header but never enabled `TEST_MODE`, so `getUserFromContext` always fell back to `"anonymous"` and the tests' `user1`/`user2` ownership assertions no longer matched reality (403 instead of 200/204/302, wrong `CreatedBy`, wrong link counts).

Each of the six test functions now sets `t.Setenv("TEST_MODE", "true")`, which is the same gate PR #186 introduced for honoring the header. This keeps the tests exercising real ownership logic (owner vs. non-owner, anonymous vs. authenticated) instead of just replacing `"user1"` with `"anonymous"` everywhere.

## Why

PR #186 (security fix) changed `auth.GetCurrentUser` / `handlers.getUserFromContext` to only trust the `X-User-ID` header when `TEST_MODE=true`, since the header is otherwise attacker-controlled. That correctly closed an auth bypass, but it left these tests stale: without `TEST_MODE`, every simulated request resolves to `"anonymous"`, and the ownership checks introduced by the same PR (`auth.IsAuthEnabled() && link.CreatedBy != userID`) then reject test cases that were written to authenticate as the link's owner. This is a distinct issue from the CORS middleware test fixes in #187/#188.

## Related

ref. https://github.com/Okabe-Junya/sandbox.internal/issues/548