### PR TITLE
Fix nginx startup crash and cross-user response cache leak

### DIFF
--- a/backend/middleware/cache_middleware.go
+++ b/backend/middleware/cache_middleware.go
@@ -154,6 +154,16 @@ func CacheMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		// Skip caching for authenticated requests. This middleware runs before
+		// AuthMiddleware and its cache key has no user dimension, so caching a
+		// response scoped to one user (e.g. their private/restricted links) would
+		// serve it to any other client that hits the same path. Anonymous requests
+		// only ever see public data, so they remain safe to cache and share.
+		if _, err := r.Cookie("session_token"); err == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		// Generate cache key
 		key := createCacheKey(r)
 

--- a/backend/middleware/cache_middleware_test.go
+++ b/backend/middleware/cache_middleware_test.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// userScopedHandler writes a body that depends on the X-User-ID header, standing
+// in for a per-user endpoint such as /api/links.
+func userScopedHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"user":%q}`, r.Header.Get("X-User-ID"))
+	})
+}
+
+// TestCacheMiddleware_DoesNotLeakAcrossAuthenticatedUsers guards the fix for the
+// cross-user cache leak: two authenticated users hitting the same path must each
+// receive their own response, never a cached copy of the other user's data.
+func TestCacheMiddleware_DoesNotLeakAcrossAuthenticatedUsers(t *testing.T) {
+	t.Parallel()
+
+	handler := CacheMiddleware(userScopedHandler())
+
+	req := func(userID string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodGet, "/api/links", nil)
+		r.AddCookie(&http.Cookie{Name: "session_token", Value: "token-" + userID})
+		r.Header.Set("X-User-ID", userID)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, r)
+		return rr
+	}
+
+	first := req("alice").Body.String()
+	second := req("bob").Body.String()
+
+	if want := `{"user":"alice"}`; first != want {
+		t.Fatalf("first response = %q, want %q", first, want)
+	}
+	if want := `{"user":"bob"}`; second != want {
+		t.Fatalf("cross-user cache leak: second response = %q, want %q", second, want)
+	}
+}
+
+// TestCacheMiddleware_AnonymousResponsesStillCached confirms the fix does not
+// disable caching for unauthenticated requests, which only ever see public data.
+func TestCacheMiddleware_AnonymousResponsesStillCached(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	counting := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"n":%d}`, calls)
+	})
+	handler := CacheMiddleware(counting)
+
+	get := func() *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodGet, "/api/public-anon-probe", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, r)
+		return rr
+	}
+
+	first := get()
+	second := get()
+
+	if got := second.Header().Get("X-Cache"); got != "HIT" {
+		t.Fatalf("second anonymous request X-Cache = %q, want HIT", got)
+	}
+	if first.Body.String() != second.Body.String() {
+		t.Fatalf("anonymous cache miss: %q != %q", first.Body.String(), second.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("upstream handler called %d times, want 1 (second served from cache)", calls)
+	}
+}

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -23,6 +23,6 @@ server {
 
     location / {
         try_files $uri $uri/ /index.html;
-        add_header Cache-Control "no-store, no-cache, must-revalidate;
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
     }
 }


### PR DESCRIPTION
## What

- **frontend/nginx.conf**: close the unterminated quoted string in the `Cache-Control` `add_header` directive.
- **backend/middleware/cache_middleware.go**: skip the response cache for requests carrying a `session_token` cookie, and add regression tests covering the cross-user case and the still-cached anonymous case.

## Why

Two independent defects found by a portfolio-wide multi-agent audit and confirmed by adversarial verification:

1. The `add_header Cache-Control "no-store, no-cache, must-revalidate;` line was missing its closing `"`, making the nginx config unparseable so the frontend container crashed on startup.
2. `CacheMiddleware` runs before `AuthMiddleware` and keys the cache on path+query only, with no user dimension. A GET response scoped to one authenticated user (e.g. their private/restricted links from `/api/links`) was cached and served to any other client hitting the same path — a cross-user data leak. Authenticated requests (identified by the `session_token` cookie) now bypass the cache; anonymous requests, which only ever see public data, remain cached.

## Related

ref. Okabe-Junya/sandbox.internal#639
